### PR TITLE
[Fix] Throw errors at the time they're created, and clear the JNT error state once thrown

### DIFF
--- a/Sources/ZippyJSON/ZippyJSONDecoder.swift
+++ b/Sources/ZippyJSON/ZippyJSONDecoder.swift
@@ -282,7 +282,6 @@ final private class __JSONDecoder: Decoder {
         return computeCodingPath(value: containers.topContainer)
     }
     let value: Value
-//    let context:
     let keyDecodingStrategy: ZippyJSONDecoder.KeyDecodingStrategy
     let convertToCamel: Bool
     let dataDecodingStrategy: ZippyJSONDecoder.DataDecodingStrategy
@@ -439,21 +438,6 @@ final private class __JSONDecoder: Decoder {
 }
 
 extension __JSONDecoder {
-    private func createContext() -> ContextPointer {
-        switch nonConformingFloatDecodingStrategy {
-        case .convertFromString(let pI, let nI, let nan):
-            return pI.withCString { pIP in
-                nI.withCString { nIP in
-                    nan.withCString { nanP in
-                        return JNTCreateContext(nIP, pIP, nanP)
-                    }
-                }
-            }
-        case .throw:
-            return JNTCreateContext("", "", "")
-        }
-    }
-
     private func throwingJNTErorr<T>(value: Value, _ execute: () -> T) throws -> T {
         let result = execute()
         let context = JNTContextFromDecoder(value)!

--- a/Tests/ZippyJSONDecoderTests.swift
+++ b/Tests/ZippyJSONDecoderTests.swift
@@ -177,7 +177,6 @@ class ZippyJSONTests: XCTestCase {
             assert(decoded == apple)
             // XCTAssertEqual(decoded, value)
         } catch {
-            fatalError()
             XCTFail("Failed to decode \(T.self) from JSON: \(error)")
         }
     }
@@ -366,6 +365,34 @@ class ZippyJSONTests: XCTestCase {
             let l: Double
         }
         _testRoundTrip(of: Test.self, json: "[1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]")
+    }
+
+    struct Example: Equatable, Codable {
+        let key: String
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.key = (try? container.decode(String.self, forKey: .key)) ?? ""
+        }
+    }
+
+    struct Example2: Equatable, Codable {
+        let key: String
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            if let double = try? container.decode(Double.self, forKey: .key) {
+                self.key = "\(double)"
+            } else {
+                self.key = try container.decode(String.self, forKey: .key)
+            }
+        }
+    }
+
+    func testOptionalInvalidValue() {
+        _testRoundTrip(of: Example.self, json: "{\"key\": 123}")
+        _testRoundTrip(of: Example2.self, json: "{\"key\": 123}")
+        _testRoundTrip(of: Example2.self, json: "{\"key\": \"123\"}")
     }
 
     func testRealJsons() {


### PR DESCRIPTION
This PR fixes #12 

The root issue was that `__JSONDecoder` was calling unbox and returning a default value, _then_ checking whether there was a JNT error later, instead of throwing the error immediately. The fix is to make these methods `throws` directly.

In order to support this fix, I had to add a couple of extra methods for checking the error context to the ZippyJSONCFamily library: those are tracked at https://github.com/michaeleisel/ZippyJSONCFamily/pull/1 - specifically, we need to get the error context from a given decoder, and reset the error context once we've thrown the error so it doesn't get thrown again on the next decode.

Happy to make any changes or hear any feedback!