### PR TITLE
Fix userInfo not being passed to __JSONDecoder

### DIFF
--- a/Sources/ZippyJSON/ZippyJSONDecoder.swift
+++ b/Sources/ZippyJSON/ZippyJSONDecoder.swift
@@ -83,7 +83,7 @@ public final class ZippyJSONDecoder {
             }
             let value: Value? = JNTDocumentFromJSON(context, bytes.baseAddress!, data.count, convertCase, &retryReason, zjd_fullPrecisionFloatParsing)
             if let value = value {
-                let decoder = __JSONDecoder(value: value, containers: JSONDecodingStorage(), keyDecodingStrategy: keyDecodingStrategy, dataDecodingStrategy: dataDecodingStrategy, dateDecodingStrategy: dateDecodingStrategy, nonConformingFloatDecodingStrategy: nonConformingFloatDecodingStrategy)
+                let decoder = __JSONDecoder(value: value, containers: JSONDecodingStorage(), keyDecodingStrategy: keyDecodingStrategy, dataDecodingStrategy: dataDecodingStrategy, dateDecodingStrategy: dateDecodingStrategy, nonConformingFloatDecodingStrategy: nonConformingFloatDecodingStrategy, userInfo: userInfo)
                 if JNTErrorDidOccur(context) {
                     throw swiftErrorFromError(context)
                 }
@@ -328,10 +328,11 @@ final private class __JSONDecoder: Decoder {
 
     fileprivate var containers: JSONDecodingStorage
 
-    init(value: Value, containers: JSONDecodingStorage, keyDecodingStrategy: ZippyJSONDecoder.KeyDecodingStrategy, dataDecodingStrategy: ZippyJSONDecoder.DataDecodingStrategy, dateDecodingStrategy: ZippyJSONDecoder.DateDecodingStrategy, nonConformingFloatDecodingStrategy: ZippyJSONDecoder.NonConformingFloatDecodingStrategy) {
+    init(value: Value, containers: JSONDecodingStorage, keyDecodingStrategy: ZippyJSONDecoder.KeyDecodingStrategy, dataDecodingStrategy: ZippyJSONDecoder.DataDecodingStrategy, dateDecodingStrategy: ZippyJSONDecoder.DateDecodingStrategy, nonConformingFloatDecodingStrategy: ZippyJSONDecoder.NonConformingFloatDecodingStrategy, userInfo: [CodingUserInfoKey : Any]) {
         self.value = value
         self.containers = containers
         self.keyDecodingStrategy = keyDecodingStrategy
+	self.userInfo = userInfo
         if case .convertFromSnakeCase = keyDecodingStrategy {
             self.convertToCamel = true
         } else {
@@ -596,7 +597,7 @@ extension __JSONDecoder {
         defer {
             containers.popContainer()
         }
-        return __JSONDecoder(value: JNTDocumentCreateCopy(value), containers: containers.createCopy(), keyDecodingStrategy: keyDecodingStrategy, dataDecodingStrategy: dataDecodingStrategy, dateDecodingStrategy: dateDecodingStrategy, nonConformingFloatDecodingStrategy: nonConformingFloatDecodingStrategy)
+        return __JSONDecoder(value: JNTDocumentCreateCopy(value), containers: containers.createCopy(), keyDecodingStrategy: keyDecodingStrategy, dataDecodingStrategy: dataDecodingStrategy, dateDecodingStrategy: dateDecodingStrategy, nonConformingFloatDecodingStrategy: nonConformingFloatDecodingStrategy, userInfo: userInfo)
     }
 
     fileprivate func unboxNestedContainer<NestedKey>(value: Value, keyedBy type: NestedKey.Type) throws -> KeyedDecodingContainer<NestedKey> where NestedKey : CodingKey {

--- a/Sources/ZippyJSON/ZippyJSONDecoder.swift
+++ b/Sources/ZippyJSON/ZippyJSONDecoder.swift
@@ -312,7 +312,7 @@ final private class Wrapper<K: CodingKey> {
 
 final private class __JSONDecoder: Decoder {
     var errorType: Any.Type? = nil
-    var userInfo: [CodingUserInfoKey : Any] = [:]
+    var userInfo: [CodingUserInfoKey : Any]
     var codingPath: [CodingKey] {
         return computeCodingPath(value: containers.topContainer)
     }
@@ -332,7 +332,7 @@ final private class __JSONDecoder: Decoder {
         self.value = value
         self.containers = containers
         self.keyDecodingStrategy = keyDecodingStrategy
-	self.userInfo = userInfo
+        self.userInfo = userInfo
         if case .convertFromSnakeCase = keyDecodingStrategy {
             self.convertToCamel = true
         } else {


### PR DESCRIPTION
The userInfo dictionary of a ZippyJSONDecoder was not shared with any __JSONDecoders that it creates.
This PR changes that.