### PR TITLE
Adds minimum deployment versions to Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,6 +6,8 @@ let package = Package(
     name: "ZippyJSON",
     platforms: [
         .iOS(.v11),
+        .tvOS(.v10),
+        .macOS(.v10_12),
     ],
     products: [
         .library(


### PR DESCRIPTION
Hello, thanks for making this package. 

I had an issue when building it for my tvOS project when using SMP. The issue is just that `ISO8601DateFormatter.Options.withInternetDateTime` is only available in tvOS 10+ so I've added minimum deployment targets in `Package.swift`. I've also added the minimum required version for macOS but not watchOS since it doesn't seem to compile the c++ anyway.

Here are screenshots of the issues I was facing in Xcode:

<img width="259" alt="Screenshot 2020-11-19 at 16 04 28" src="https://user-images.githubusercontent.com/8556609/99694018-deae9d80-2a83-11eb-833e-acd6c31abc4e.png">
<img width="259" alt="Screenshot 2020-11-19 at 16 04 17" src="https://user-images.githubusercontent.com/8556609/99694022-dfdfca80-2a83-11eb-8812-8324dbc75404.png">

And I have checked that it fixes the problem in this project:

[Testing.zip](https://github.com/michaeleisel/ZippyJSON/files/5568224/Testing.zip)