### PR TITLE
Prefer AnyObject over class for class-constrained protocol

### DIFF
--- a/Sources/ZippyJSON/ZippyJSONDecoder.swift
+++ b/Sources/ZippyJSON/ZippyJSONDecoder.swift
@@ -315,7 +315,7 @@ private func computeCodingPathInternal(value: Value) -> [JSONKey] {
 }
 
 // Wrapper and AnyWrapper allow for isKnownUniquelyReferenced to work
-private protocol AnyWrapper: class {
+private protocol AnyWrapper: AnyObject {
 }
 
 extension Wrapper: AnyWrapper {


### PR DESCRIPTION
With Swift 5.5 in Xcode 13, this is now a warning:

```
/<redacted>/ZippyJSON/Sources/ZippyJSON/ZippyJSONDecoder.swift:318:30: warning: using 'class' keyword to define a class-constrained protocol is deprecated; use 'AnyObject' instead
  private protocol AnyWrapper: class {
```

This should have no functional difference, and is also backwards-compatible with previous versions of Swift.