### PR TITLE
Update the required version of ZippyJSONCFamily to match this package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/michaeleisel/JJLISO8601DateFormatter", .upToNextMajor(from: "0.1.5")),
-        .package(url: "https://github.com/michaeleisel/ZippyJSONCFamily", .exact("1.2.5")),
+        .package(url: "https://github.com/michaeleisel/ZippyJSONCFamily", .exact("1.2.9")),
     ],
     targets: [
         .target(


### PR DESCRIPTION
The proposed changes fix #56.