### PR TITLE
[Deps] Bump JJLISO8601DateFormatter version 1.5.0 → 1.7.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,25 +1,23 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "JJLISO8601DateFormatter",
-        "repositoryURL": "https://github.com/michaeleisel/JJLISO8601DateFormatter",
-        "state": {
-          "branch": null,
-          "revision": "de422afd9a47b72703c30a81423c478337191390",
-          "version": "0.1.6"
-        }
-      },
-      {
-        "package": "ZippyJSONCFamily",
-        "repositoryURL": "https://github.com/michaeleisel/ZippyJSONCFamily",
-        "state": {
-          "branch": null,
-          "revision": "8abdd7a5e943afe68e7b03fdaa63b21c042a3893",
-          "version": "1.2.9"
-        }
+  "pins" : [
+    {
+      "identity" : "jjliso8601dateformatter",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/michaeleisel/JJLISO8601DateFormatter",
+      "state" : {
+        "revision" : "ed1d996123688bade6e895aa49595f0d862900e7",
+        "version" : "0.1.7"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "zippyjsoncfamily",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/michaeleisel/ZippyJSONCFamily",
+      "state" : {
+        "revision" : "8abdd7a5e943afe68e7b03fdaa63b21c042a3893",
+        "version" : "1.2.9"
+      }
+    }
+  ],
+  "version" : 2
 }

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
             targets: ["ZippyJSON"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/michaeleisel/JJLISO8601DateFormatter", .upToNextMajor(from: "0.1.5")),
+        .package(url: "https://github.com/michaeleisel/JJLISO8601DateFormatter", .upToNextMajor(from: "0.1.7")),
         .package(url: "https://github.com/michaeleisel/ZippyJSONCFamily", .exact("1.2.9")),
     ],
     targets: [

--- a/ZippyJSON.podspec
+++ b/ZippyJSON.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'ZippyJSON'
-  s.version          = '1.2.10'
+  s.version          = '1.2.11'
   s.summary          = 'A ~4x faster, drop-in replacement for JSONDecoder'
 
   s.description      = <<-DESC
@@ -18,7 +18,7 @@ ZippyJSON is a very fast library for converting JSON into Swift objects. It is f
 
   s.source_files = 'Sources/**/*.{h,hh,mm,m,c,cpp,swift}'
   s.dependency 'ZippyJSONCFamily', '1.2.9'
-  s.dependency 'JJLISO8601DateFormatter', '0.1.5'
+  s.dependency 'JJLISO8601DateFormatter', '0.1.7'
   s.swift_version = '5.0'
 
   s.test_spec 'Tests' do |test_spec|


### PR DESCRIPTION
When using Xcode 16 Beta 1, you see the following error:

```c++
ios/Pods/managed/JJLISO8601DateFormatter/Sources/Sources/JJLISO8601DateFormatter/Vendor/tzdb/tzfile__.h:47:1: error: missing '#include <sys/_types/_ssize_t.h>'; 'ssize_t' must be declared before it is used
   47 | ssize_t jjl_saferead(int fd, void *buffer, size_t nbytes);
      | ^
/Applications/Xcode-16.0.0-Beta.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator18.0.sdk/usr/include/sys/_types/_ssize_t.h:31:33: note: declaration here is not visible
   31 | typedef __darwin_ssize_t        ssize_t;
      |                                 ^
1 error generated.
```

This issue is already fixed in JJLISO8601DateFormatter here: https://github.com/michaeleisel/JJLISO8601DateFormatter/blob/master/Sources/JJLISO8601DateFormatter/Vendor/tzdb/tzfile__.h#L5 but we just need `ZippyJSON` to use this newer version.


## Steps Taken
1. update `1.5.0` → `1.7.0` in `ZippyJSON.podspec
2. update `1.5.0` → `1.7.0` in `Package.swift`
3. run `swift build` to update `Package.resolved`

## Please Review
@michaeleisel 
cc: @dfed @brentleyjones